### PR TITLE
Add AddCharVariable() for creating NC_CHAR array variables 

### DIFF
--- a/ScientificDataSet/Core/DataSet.cs
+++ b/ScientificDataSet/Core/DataSet.cs
@@ -1317,7 +1317,7 @@ namespace Microsoft.Research.Science.Data
             return var;
         }
 
-        private static bool HasDuplicates(string[] dims)
+        protected static bool HasDuplicates(string[] dims)
         {
             if (dims.Length == 0 || dims.Length == 1) return false;
 

--- a/ScientificDataSet/Providers/NetCDF/NetCdfVariable.cs
+++ b/ScientificDataSet/Providers/NetCDF/NetCdfVariable.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Research.Science.Data.NetCDF4
             UpdateDimIds();
         }
 
-        internal static NetCdfVariable<DataType> Create(NetCDFDataSet dataSet, string name, string[] dims)
+        internal static NetCdfVariable<DataType> Create(NetCDFDataSet dataSet, string name, string[] dims, bool isChar)
         {
             if (dims == null) // scalar variable
                 dims = new string[0];
@@ -152,7 +152,11 @@ namespace Microsoft.Research.Science.Data.NetCDF4
             if (nc_name != name)
                 Debug.WriteLineIf(NetCDFDataSet.TraceNetCDFDataSet.TraceVerbose, "NetCDF: name has illegal chars; internal variable name is " + nc_name);
 
-            res = NetCDF.nc_def_var(dataSet.NcId, nc_name, NetCDF.GetNcType(typeof(DataType)), dimids, out varid);
+            if (typeof(DataType) == typeof(byte) && isChar) {
+                res = NetCDF.nc_def_var(dataSet.NcId, nc_name, NcType.NC_CHAR, dimids, out varid);
+            } else {
+                res = NetCDF.nc_def_var(dataSet.NcId, nc_name, NetCDF.GetNcType(typeof(DataType)), dimids, out varid);
+            }
             for (int count = 1; res == (int)ResultCode.NC_ENAMEINUSE; )
             {
                 // Keep trying to create variable with different names


### PR DESCRIPTION
SDSlite currently multiplexes the `ubyte` type for `char` and `ubyte` when reading and writing variable data. However, it's currently not possible to _create_ a variable of type `char` using `AddVariable<>()`. The problem is that the .NET `char` type is 16-bits, whereas the NC type is 8-bits. When creating a variable of type `byte`, it always becomes `nc_ubyte`. This patch adds a new specialized method `AddCharVariable()` for NC DataSets which creates `char` typed variables. Not very nice, but the best quick fix I could come up with. 