### PR TITLE
[2.0.4] modifies netcdf.dll search order on Windows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
 
   build-test-linux:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,6 +50,8 @@ jobs:
       run: sudo apt-get install libnetcdf-dev
     - name: Test
       run: dotnet test --verbosity normal SDSLiteTests
+      env:
+        LD_DEBUG: all
 
   build-test-macos:
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
 
   build-test-linux:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -50,8 +50,6 @@ jobs:
       run: sudo apt-get install libnetcdf-dev
     - name: Test
       run: dotnet test --verbosity normal SDSLiteTests
-      env:
-        LD_DEBUG: all
 
   build-test-macos:
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
 
   build-test-linux:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -25,8 +25,8 @@ jobs:
     - name: Download NetCDF
       shell: pwsh
       run: |
-        Invoke-WebRequest $env:URL_NETCDF_WIN -OutFile netcdf.exe
-        7z x netcdf.exe bin/* -o${{ runner.temp }}
+        Invoke-WebRequest $env:URL_NETCDF_WIN -OutFile ${{ runner.temp }}\netcdf.exe
+        7z x ${{ runner.temp }}\netcdf.exe bin/* -o${{ runner.temp }} -y
     - name: Test
       run: dotnet test --no-build --verbosity normal
       env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
 env:
-  URL_NETCDF_WIN: http://www.unidata.ucar.edu/downloads/netcdf/ftp/netCDF4.7.2-NC4-64.exe
+  URL_NETCDF_WIN: https://downloads.unidata.ucar.edu/netcdf-c/4.9.2/netCDF4.9.2-NC4-64.exe
 jobs:
   build-test-windows:
 
@@ -26,10 +26,11 @@ jobs:
       shell: pwsh
       run: |
         Invoke-WebRequest $env:URL_NETCDF_WIN -OutFile netcdf.exe
-        7z x netcdf.exe bin/*
-        Add-Content -Path $env:GITHUB_PATH -Value (Join-Path (Get-Location) "bin")  -Encoding UTF8
+        7z x netcdf.exe bin/* -o${{ runner.temp }}
     - name: Test
       run: dotnet test --no-build --verbosity normal
+      env:
+        LIBNETCDFPATH: ${{ runner.temp }}\bin\netcdf.dll
 
   build-test-linux:
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -60,7 +60,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Common/Version.proj
+++ b/Common/Version.proj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
     <Copyright>(c) Microsoft Corporation. All rights reserved</Copyright>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -12,15 +12,24 @@ SDSLite requires a platform dependent library available from [http://www.unidata
 
 ### Windows
 
-For Windows go to [http://www.unidata.ucar.edu/software/netcdf/docs/winbin.html](http://www.unidata.ucar.edu/software/netcdf/docs/winbin.html) and download the version of netCDF4 (without DAP) corresponding to your machine, either 32 or 64 bit. These are
-currently: https://www.unidata.ucar.edu/downloads/netcdf/ftp/netCDF4.7.4-NC4-32.exe or https://www.unidata.ucar.edu/downloads/netcdf/ftp/netCDF4.7.4-NC4-64.exe
-When you install this library select the option to add its location to your system PATH, so that SDSLite can find it.
+For Windows go to [http://www.unidata.ucar.edu/software/netcdf/docs/winbin.html](http://www.unidata.ucar.edu/software/netcdf/docs/winbin.html) and download the version of netCDF4 (without DAP) corresponding to your machine, either 32 or 64 bit.
+As of May 2023 these are: https://downloads.unidata.ucar.edu/netcdf-c/4.9.2/netCDF4.9.2-NC4-64.exe or https://downloads.unidata.ucar.edu/netcdf-c/4.9.2/netCDF4.9.2-NC4-64.exe.
+
+The Scientific DataSet library looks for `netcdf.dll` file in the following locations:
+- `LIBNETCDFPATH` environment variable if it contains full path of the `netcdf.dll` file;
+- Current directory;
+- In the same directory as the `ScientificDataSet.dll` assembly;
+- PATH environment variable;
+- Default installation directory of netCDF4.
 
 ### Linux
 
 For Linux install pre-built netCDF-C libraries. For example on Ubuntu:
 
 `sudo apt-get install libnetcdf-dev`
+
+If `LIBNETCDFPATH` environment variable contains full path of the `.so*` file, this will be used.
+Otherwise, standard Linux library search for `libnetcdf.so` will be used.
 
 ### MacOS
 

--- a/SDSLiteTests/SDSLiteTests.csproj
+++ b/SDSLiteTests/SDSLiteTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/ScientificDataSet/Providers/NetCDF/Interop/NetCDF.cs
+++ b/ScientificDataSet/Providers/NetCDF/Interop/NetCDF.cs
@@ -542,7 +542,8 @@ namespace NetCDFInterop
             switch (platform)
             {
                 case PlatformID.Win32NT:
-                    path = Environment.GetEnvironmentVariable("LIBNETCDFPATH");
+                    path = Environment.GetEnvironmentVariable("LIBNETCDFPATH")
+                        ?? Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "netcdf.dll");
                     if (!string.IsNullOrWhiteSpace(path) && System.IO.File.Exists(path))
                     {
                         Environment.SetEnvironmentVariable("PATH",
@@ -552,7 +553,7 @@ namespace NetCDFInterop
                     var name = "netcdf.dll";
                     // try find the file in current directory, alongside the executing assembly
                     // and then in directories from PATH environmental variable.
-                    path = new string[] { Environment.CurrentDirectory, System.Reflection.Assembly.GetExecutingAssembly().Location}
+                    path = new string[] { Environment.CurrentDirectory }
                         .Concat(Environment.GetEnvironmentVariable("PATH").Split(';'))
                         .FirstOrDefault(d => File.Exists(Path.Combine(d, name)));
                     if (null == path)

--- a/ScientificDataSet/Providers/NetCDF/Interop/NetCDF.cs
+++ b/ScientificDataSet/Providers/NetCDF/Interop/NetCDF.cs
@@ -537,15 +537,18 @@ namespace NetCDFInterop
         static DynamicInterop.UnmanagedDll native;
         private static string GetPath()
         {
-            string path = Environment.GetEnvironmentVariable("LIBNETCDFPATH");
-            if (!string.IsNullOrWhiteSpace(path) && System.IO.File.Exists(path))
-            {
-                return path;
-            }
+            string path;
             var platform = DynamicInterop.PlatformUtility.GetPlatform();
             switch (platform)
             {
                 case PlatformID.Win32NT:
+                    path = Environment.GetEnvironmentVariable("LIBNETCDFPATH");
+                    if (!string.IsNullOrWhiteSpace(path) && System.IO.File.Exists(path))
+                    {
+                        Environment.SetEnvironmentVariable("PATH",
+                            Environment.GetEnvironmentVariable("PATH") + ";" + Path.GetDirectoryName(path));
+                        return path;
+                    }
                     var name = "netcdf.dll";
                     // try find the file in current directory, alongside the executing assembly
                     // and then in directories from PATH environmental variable.
@@ -587,6 +590,11 @@ namespace NetCDFInterop
                 case PlatformID.MacOSX:
                     return "libnetcdf.dylib";
                 case PlatformID.Unix:
+                    path = Environment.GetEnvironmentVariable("LIBNETCDFPATH");
+                    if (!string.IsNullOrWhiteSpace(path) && System.IO.File.Exists(path))
+                    {
+                        return path;
+                    }
                     return "libnetcdf.so";
                 default:
                     throw new NotSupportedException(String.Format("Platform not supported: {0}", platform));

--- a/ScientificDataSet/Providers/NetCDF/NetCDFUri.cs
+++ b/ScientificDataSet/Providers/NetCDF/NetCDFUri.cs
@@ -139,7 +139,8 @@ namespace Microsoft.Research.Science.Data.NetCDF4
         Fast = 3,
         Normal = 5,
         Good = 7,
-        Best = 9
+        Best = 9,
+        BestWithShuffle = 10
     }
 }
 

--- a/ScientificDataSet/Providers/NetCDF/NetCdfVariable.cs
+++ b/ScientificDataSet/Providers/NetCDF/NetCdfVariable.cs
@@ -160,12 +160,12 @@ namespace Microsoft.Research.Science.Data.NetCDF4
             }
             NetCDFDataSet.HandleResult(res);
 
-            // Non scalar variables can be compressed.
-            // It is regulated by the uri parameter "deflate".
-            if (dims.Length > 0)
+            // Scalar variables and strings cannot be compressed.
+            // For other variables compression is regulated by the uri parameter "deflate".
+            if (dataSet.Deflate != DeflateLevel.Off && dims.Length > 0 && typeof(DataType) != typeof(string))
             {
-                if (dataSet.Deflate == DeflateLevel.Off)
-                    res = NetCDF.nc_def_var_deflate(dataSet.NcId, varid, 0, 0, 0);
+                if (dataSet.Deflate == DeflateLevel.BestWithShuffle)
+                    res = NetCDF.nc_def_var_deflate(dataSet.NcId, varid, 1, 1, 9);
                 else
                     res = NetCDF.nc_def_var_deflate(dataSet.NcId, varid, 0, 1, (int)dataSet.Deflate);
                 NetCDFDataSet.HandleResult(res);

--- a/sdsutil/sdsutil.csproj
+++ b/sdsutil/sdsutil.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   


### PR DESCRIPTION
- Tests are run against v4.9.2 of netCDF.
- Disable netcdf compression of string variables, see #36. 
- Fix Linux version on 20.04 LTS.